### PR TITLE
Added a console to wxApplication along with some basic commands

### DIFF
--- a/BaseApplication/BaseApplication/BaseApplication.h
+++ b/BaseApplication/BaseApplication/BaseApplication.h
@@ -122,6 +122,8 @@ public:
 
 	virtual bool SelectFile(char** result, const char* fileMask = 0) = 0;
 
+    virtual void ConsolePrint(const char* text) = 0;
+
 
 	// IMachineToApplication
 
@@ -148,15 +150,31 @@ protected:
 	virtual void CloseMacro(Archive* archive) = 0;
 
 
-    //Console
+    // Console command framework
 
     typedef void (BaseApplication::*ConsoleCommandHandler)(const char* command, const char* params);
-    virtual void AddConsoleCommandHandler(const char* command, ConsoleCommandHandler func);
+    virtual void AddConsoleCommand(const char* command, ConsoleCommandHandler func, const char* helpText);
     
     virtual unsigned int NumConsoleCommands();
     virtual const char* GetConsoleCommand(unsigned int index);
 
-    virtual void ExecuteConsoleCommand(const char* command);
+    virtual bool ExecuteConsoleCommand(const char* command); ///< Returns true if the command was successfully executed. False otherwise.
+
+
+    // Built-in console commands
+
+    virtual void CommandHelp(const char* command, const char* params);
+    virtual void CommandQuit(const char* command, const char* params);
+    virtual void CommandLoad(const char* command, const char* params);
+    virtual void CommandPause(const char* command, const char* params);
+    virtual void CommandRun(const char* command, const char* params);
+    virtual void CommandSaveState(const char* command, const char* params);
+    virtual void CommandLoadState(const char* command, const char* params);
+    virtual void CommandSpeed(const char* command, const char* params);
+    virtual void CommandMute(const char* command, const char* params);
+    virtual void CommandDisplayFilter(const char* command, const char* params);
+    virtual void CommandVsync(const char* command, const char* params);
+    virtual void CommandBackground(const char* command, const char* params);
 
 
 	bool m_shutdownRequested;
@@ -180,6 +198,7 @@ protected:
     struct ConsoleCommandInfo
     {
         char command[16];
+        char helpText[256];
         ConsoleCommandHandler func;
     };
     static const unsigned int MaxConsoleCommands = 1024;

--- a/BaseApplication/BaseApplication/BaseApplication.h
+++ b/BaseApplication/BaseApplication/BaseApplication.h
@@ -148,6 +148,17 @@ protected:
 	virtual void CloseMacro(Archive* archive) = 0;
 
 
+    //Console
+
+    typedef void (BaseApplication::*ConsoleCommandHandler)(const char* command, const char* params);
+    virtual void AddConsoleCommandHandler(const char* command, ConsoleCommandHandler func);
+    
+    virtual unsigned int NumConsoleCommands();
+    virtual const char* GetConsoleCommand(unsigned int index);
+
+    virtual void ExecuteConsoleCommand(const char* command);
+
+
 	bool m_shutdownRequested;
 
 	//Emulated machine
@@ -164,6 +175,16 @@ protected:
 	MachineRunner* m_machineRunner;
 
 	char m_lastRomLoaded[1024];
+
+    //Console commands
+    struct ConsoleCommandInfo
+    {
+        char command[16];
+        ConsoleCommandHandler func;
+    };
+    static const unsigned int MaxConsoleCommands = 1024;
+    ConsoleCommandInfo m_consoleCommands[MaxConsoleCommands];
+    unsigned int m_numConsoleCommands;
 };
 
 }	//namespace Emunisce

--- a/BaseApplication/BaseApplication/IUserInterface.h
+++ b/BaseApplication/BaseApplication/IUserInterface.h
@@ -160,6 +160,8 @@ public:
 	virtual PromptResult::Type DisplayPrompt(PromptType::Type promptType, const char* title, const char* message, void** extraResult) = 0;	///<Displays a prompt the user and blocks until the prompt is answered.  extraResult is for responses from the user that can't be returned as PromptResult values.
 
 	virtual bool SelectFile(char** result, const char* fileMask = 0) = 0;	///<Prompts the user to select a file.  Allocates result, sets it to the absolute path to the file, and returns true on success.  On cancellation, failure, or an invalid file selection, result is unchanged and the function returns false.
+
+    virtual void ConsolePrint(const char* text) = 0;    ///<Displays a message in the console.
 };
 
 }	//namespace Emunisce

--- a/Platform/SecureCrt.h
+++ b/Platform/SecureCrt.h
@@ -34,6 +34,9 @@ along with Emunisce.  If not, see <http://www.gnu.org/licenses/>.
 #include <string.h>
 
 
+#define _stricmp strcasecmp
+
+
 inline int freopen_s(FILE** outFile, const char* path, const char* mode, FILE* stream)
 {
     //todo

--- a/wxApplication/Application.cpp
+++ b/wxApplication/Application.cpp
@@ -73,6 +73,7 @@ void Application::NotifyMachineChanged(IEmulatedMachine* newMachine)
 void Application::RequestShutdown()
 {
 	BaseApplication::RequestShutdown();
+    m_consoleWindow->Close();
 	m_windowMain->Close();
 	m_frame->Close();
 }
@@ -151,6 +152,11 @@ bool Application::SelectFile(char** result, const char* fileMask)
     strcpy_s(*result, bufferSize, openFileDialog.GetPath().ToAscii());
 
     return true;
+}
+
+void Application::ConsolePrint(const char* text)
+{
+    m_consoleWindow->ConsolePrint(text);
 }
 
 
@@ -480,6 +486,12 @@ bool Application::OnInit()
     m_consoleWindow = new ConsoleWindow(this, m_frame);
     m_consoleWindow->GiveFocus();
 
+    ConsolePrint("Welcome to Emunisce\n");
+    ConsolePrint("===================\n");
+    ConsolePrint("Press tilde (`) to switch focus between the console and the game\n");
+    ConsolePrint("Type 'help' to see a list of commands\n");
+    ConsolePrint("\n");
+
 
     // Initialize the renderer and hand off to the machine
 
@@ -507,4 +519,9 @@ void Application::ShowGameWindow()
     m_frame->Raise();
 
     m_windowMain->SetFocus();
+}
+
+bool Application::ExecuteConsoleCommand(const char* command)
+{
+    return BaseApplication::ExecuteConsoleCommand(command);
 }

--- a/wxApplication/Application.cpp
+++ b/wxApplication/Application.cpp
@@ -24,6 +24,8 @@ using namespace Emunisce;
 
 //wx
 #include "wx/sizer.h"
+#include "wx/textctrl.h"
+#include "ConsoleWindow.h"
 #include "WindowMain.h"
 
 //Platform
@@ -49,6 +51,8 @@ using namespace Emunisce;
 Application::Application()
 {
 	m_renderer = new OpenGLRenderer();
+
+    m_consoleWindow = nullptr;
 
 	MapDefaultKeys();
 }
@@ -190,6 +194,9 @@ void Application::KeyDown(int key)
 
     else if(key == 'T')
         DisplayImportantMessage(MessageType::Information, "test");
+
+    else if(key == '`')
+        ShowConsoleWindow();
 
     else if(key == 'O')
     {
@@ -453,7 +460,8 @@ IMPLEMENT_APP(Application)
 
 bool Application::OnInit()
 {
-    wxBoxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
+    // Set up the main window and renderer frame
+
     m_frame = new wxFrame((wxFrame *)nullptr, -1, wxT("Emunisce"), wxPoint(50,50), wxSize(320,240));
 
     int args[] = {WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_DEPTH_SIZE, 16, 0};
@@ -461,6 +469,7 @@ bool Application::OnInit()
     m_windowMain = new WindowMain(m_frame, args);
     m_windowMain->SetApplication(this);
 
+    wxBoxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
     sizer->Add(m_windowMain, 1, wxEXPAND);
 
     m_frame->SetSizer(sizer);
@@ -468,8 +477,11 @@ bool Application::OnInit()
 
     m_frame->Show();
 
-    m_windowMain->SetFocus();
+    m_consoleWindow = new ConsoleWindow(this, m_frame);
+    m_consoleWindow->GiveFocus();
 
+
+    // Initialize the renderer and hand off to the machine
 
 	m_renderer->Initialize(nullptr);
 
@@ -482,4 +494,17 @@ bool Application::OnInit()
 	Run();
 
     return true;
+}
+
+void Application::ShowConsoleWindow()
+{
+    m_consoleWindow->GiveFocus();
+}
+
+void Application::ShowGameWindow()
+{
+    m_frame->Show();
+    m_frame->Raise();
+
+    m_windowMain->SetFocus();
 }

--- a/wxApplication/Application.h
+++ b/wxApplication/Application.h
@@ -34,6 +34,7 @@ namespace Emunisce
 {
 
 class WindowMain;
+class ConsoleWindow;
 
 class Application : public wxApp, public BaseApplication
 {
@@ -72,6 +73,12 @@ public:
 
 	virtual void KeyDown(int key);
 	virtual void KeyUp(int key);
+
+
+    // wxApplication
+
+    void ShowConsoleWindow();
+    void ShowGameWindow();
 
 
 protected:
@@ -120,6 +127,7 @@ protected:
 
     wxFrame* m_frame;
     WindowMain* m_windowMain;
+    ConsoleWindow* m_consoleWindow;
 };
 
 }   //namespace Emunisce

--- a/wxApplication/Application.h
+++ b/wxApplication/Application.h
@@ -60,6 +60,8 @@ public:
 
 	virtual bool SelectFile(char** result, const char* fileMask);
 
+    virtual void ConsolePrint(const char* text);
+
 	virtual unsigned int GetRomDataSize(const char* title);
 
 
@@ -79,6 +81,8 @@ public:
 
     void ShowConsoleWindow();
     void ShowGameWindow();
+
+    virtual bool ExecuteConsoleCommand(const char* command); ///< Move to public for use from ConsoleWindow
 
 
 protected:

--- a/wxApplication/ConsoleWindow.cpp
+++ b/wxApplication/ConsoleWindow.cpp
@@ -1,0 +1,193 @@
+/*
+Copyright (C) 2011 by Andrew Gray
+arkhaix@emunisce.com
+
+This file is part of Emunisce.
+
+Emunisce is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+The full license is available at http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+
+Emunisce is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Emunisce.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "ConsoleWindow.h"
+using namespace Emunisce;
+
+#include "Application.h"
+
+class WtfTextCtrl : public wxTextCtrl
+{
+public:
+
+    WtfTextCtrl(ConsoleWindow* console, wxWindow *parent, wxWindowID id, const wxString &value = wxEmptyString, const wxPoint &pos = wxDefaultPosition, const wxSize &size = wxDefaultSize, long style = 0L, const wxValidator &validator = wxDefaultValidator, const wxString &name = wxTextCtrlNameStr) :
+        wxTextCtrl(parent, id, value, pos, size, style, validator, name)
+    {
+        Connect(wxEVT_KEY_DOWN, wxKeyEventHandler(WtfTextCtrl::OnKeyDown));
+        Connect(wxEVT_KEY_UP, wxKeyEventHandler(WtfTextCtrl::OnKeyUp));
+        Connect(wxEVT_COMMAND_TEXT_UPDATED, wxTextEventHandler(WtfTextCtrl::OnText));
+        Connect(wxEVT_COMMAND_TEXT_ENTER, wxTextEventHandler(WtfTextCtrl::OnTextEnter));
+        Connect(wxEVT_SET_FOCUS, wxFocusEventHandler(WtfTextCtrl::OnSetFocus));
+
+        m_console = console;
+    }
+
+    void OnKeyDown(wxKeyEvent& event)
+    {
+        m_console->OnKeyDown(event);
+    }
+
+    void OnKeyUp(wxKeyEvent& event)
+    {
+        m_console->OnKeyUp(event);
+    }
+
+    void OnText(wxCommandEvent& event)
+    {
+        m_console->OnText(event);
+    }
+
+    void OnTextEnter(wxCommandEvent& event)
+    {
+        m_console->OnTextEnter(event);
+    }
+
+    void OnSetFocus(wxFocusEvent& event)
+    {
+        m_console->OnSetFocus(event);
+    }
+
+
+private:
+
+    ConsoleWindow* m_console;
+};
+
+class ConsoleFrame : public wxFrame
+{
+public:
+
+    ConsoleFrame(ConsoleWindow* consoleWindow, wxFrame* parent, wxString& title, wxPoint& position, wxSize& size)
+        : wxFrame(parent, wxID_ANY, title, position, size)
+    {
+        m_consoleWindow = consoleWindow;
+    }
+
+    void OnClose(wxCloseEvent& event)
+    {
+        m_consoleWindow->OnFrameClosed(event);
+        event.Skip(true);
+    }
+
+private:
+
+    ConsoleWindow* m_consoleWindow;
+};
+
+ConsoleWindow::ConsoleWindow(Application* application, wxFrame* mainFrame)
+{
+    Initialize(application, mainFrame);
+}
+
+ConsoleWindow::~ConsoleWindow()
+{
+}
+
+void ConsoleWindow::Initialize(Application* application, wxFrame* mainFrame)
+{
+    m_application = application;
+    m_mainFrame = mainFrame;
+
+    wxString title(wxT("Emunisce Console"));
+    wxSize consoleSize(400, 200);
+    wxPoint consolePos = mainFrame->GetPosition();
+    consolePos.x += mainFrame->GetSize().GetWidth();
+
+    m_frame = new ConsoleFrame(this, mainFrame, title, consolePos, consoleSize);
+
+    m_output =  new WtfTextCtrl(this, m_frame, wxID_ANY, wxT(""), wxPoint(0,0), wxSize(400,180),
+        wxTE_READONLY | wxTE_MULTILINE | wxTE_RICH | wxTE_BESTWRAP | wxTE_AUTO_SCROLL);
+    m_output->SetBackgroundColour(*wxBLACK);
+    m_output->SetDefaultStyle(wxTextAttr(*wxLIGHT_GREY, *wxBLACK));
+
+    m_input =  new WtfTextCtrl(this, m_frame, wxID_ANY, wxT(""), wxPoint(0,180), wxSize(400,20),
+        wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
+    m_input->SetBackgroundColour(*wxBLACK);
+    m_input->SetDefaultStyle(wxTextAttr(*wxLIGHT_GREY, *wxBLACK));
+
+    m_frame->Show();
+}
+
+void ConsoleWindow::GiveFocus()
+{
+    if(m_frame == nullptr)
+        Initialize(m_application, m_mainFrame);
+
+    m_frame->Show();
+    m_frame->Raise();
+
+    m_input->SetFocus();
+}
+
+
+void ConsoleWindow::OnKeyDown(wxKeyEvent& event)
+{
+    int key = event.GetKeyCode();
+
+    if(key == (int)'`' || key == WXK_ESCAPE)
+    {
+        m_application->ShowGameWindow();
+        event.Skip(false);
+    }
+
+    else
+    {
+        event.Skip(true);
+    }
+}
+
+void ConsoleWindow::OnKeyUp(wxKeyEvent& event)
+{
+    event.Skip(true);
+}
+
+void ConsoleWindow::OnText(wxCommandEvent& event)
+{
+    event.Skip(true);
+}
+
+void ConsoleWindow::OnTextEnter(wxCommandEvent& event)
+{
+    *m_output << m_input->GetValue() << wxT("\n");
+    m_input->SetValue(wxT(""));
+    event.Skip(true);
+}
+
+void ConsoleWindow::OnSetFocus(wxFocusEvent& event)
+{
+    if(event.GetWindow() != m_input)
+    {
+        m_input->SetFocus();
+    }
+
+    event.Skip(true);
+}
+
+void ConsoleWindow::OnFrameClosed(wxCloseEvent& event)
+{
+    delete m_output;
+    m_output = nullptr;
+
+    delete m_input;
+    m_input = nullptr;
+
+    delete m_frame;
+    m_frame = nullptr;
+}

--- a/wxApplication/ConsoleWindow.cpp
+++ b/wxApplication/ConsoleWindow.cpp
@@ -23,18 +23,18 @@ using namespace Emunisce;
 
 #include "Application.h"
 
-class WtfTextCtrl : public wxTextCtrl
+class ConsoleTextCtrl : public wxTextCtrl
 {
 public:
 
-    WtfTextCtrl(ConsoleWindow* console, wxWindow *parent, wxWindowID id, const wxString &value = wxEmptyString, const wxPoint &pos = wxDefaultPosition, const wxSize &size = wxDefaultSize, long style = 0L, const wxValidator &validator = wxDefaultValidator, const wxString &name = wxTextCtrlNameStr) :
+    ConsoleTextCtrl(ConsoleWindow* console, wxWindow *parent, wxWindowID id, const wxString &value = wxEmptyString, const wxPoint &pos = wxDefaultPosition, const wxSize &size = wxDefaultSize, long style = 0L, const wxValidator &validator = wxDefaultValidator, const wxString &name = wxTextCtrlNameStr) :
         wxTextCtrl(parent, id, value, pos, size, style, validator, name)
     {
-        Connect(wxEVT_KEY_DOWN, wxKeyEventHandler(WtfTextCtrl::OnKeyDown));
-        Connect(wxEVT_KEY_UP, wxKeyEventHandler(WtfTextCtrl::OnKeyUp));
-        Connect(wxEVT_COMMAND_TEXT_UPDATED, wxTextEventHandler(WtfTextCtrl::OnText));
-        Connect(wxEVT_COMMAND_TEXT_ENTER, wxTextEventHandler(WtfTextCtrl::OnTextEnter));
-        Connect(wxEVT_SET_FOCUS, wxFocusEventHandler(WtfTextCtrl::OnSetFocus));
+        Connect(wxEVT_KEY_DOWN, wxKeyEventHandler(ConsoleTextCtrl::OnKeyDown));
+        Connect(wxEVT_KEY_UP, wxKeyEventHandler(ConsoleTextCtrl::OnKeyUp));
+        Connect(wxEVT_COMMAND_TEXT_UPDATED, wxTextEventHandler(ConsoleTextCtrl::OnText));
+        Connect(wxEVT_COMMAND_TEXT_ENTER, wxTextEventHandler(ConsoleTextCtrl::OnTextEnter));
+        Connect(wxEVT_SET_FOCUS, wxFocusEventHandler(ConsoleTextCtrl::OnSetFocus));
 
         m_console = console;
     }
@@ -112,12 +112,12 @@ void ConsoleWindow::Initialize(Application* application, wxFrame* mainFrame)
 
     m_frame = new ConsoleFrame(this, mainFrame, title, consolePos, consoleSize);
 
-    m_output =  new WtfTextCtrl(this, m_frame, wxID_ANY, wxT(""), wxPoint(0,0), wxSize(400,180),
+    m_output =  new ConsoleTextCtrl(this, m_frame, wxID_ANY, wxT(""), wxPoint(0,0), wxSize(400,180),
         wxTE_READONLY | wxTE_MULTILINE | wxTE_RICH | wxTE_BESTWRAP | wxTE_AUTO_SCROLL);
     m_output->SetBackgroundColour(*wxBLACK);
     m_output->SetDefaultStyle(wxTextAttr(*wxLIGHT_GREY, *wxBLACK));
 
-    m_input =  new WtfTextCtrl(this, m_frame, wxID_ANY, wxT(""), wxPoint(0,180), wxSize(400,20),
+    m_input =  new ConsoleTextCtrl(this, m_frame, wxID_ANY, wxT(""), wxPoint(0,180), wxSize(400,20),
         wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
     m_input->SetBackgroundColour(*wxBLACK);
     m_input->SetDefaultStyle(wxTextAttr(*wxLIGHT_GREY, *wxBLACK));

--- a/wxApplication/ConsoleWindow.cpp
+++ b/wxApplication/ConsoleWindow.cpp
@@ -136,6 +136,19 @@ void ConsoleWindow::GiveFocus()
     m_input->SetFocus();
 }
 
+void ConsoleWindow::Close()
+{
+    m_frame->Close();
+}
+
+void ConsoleWindow::ConsolePrint(const char* text)
+{
+    if(m_output != nullptr)
+    {
+        *m_output << wxString::FromAscii(text);
+    }
+}
+
 
 void ConsoleWindow::OnKeyDown(wxKeyEvent& event)
 {
@@ -165,7 +178,14 @@ void ConsoleWindow::OnText(wxCommandEvent& event)
 
 void ConsoleWindow::OnTextEnter(wxCommandEvent& event)
 {
-    *m_output << m_input->GetValue() << wxT("\n");
+    *m_output << wxT("> ") << m_input->GetValue() << wxT("\n");
+
+    bool result = m_application->ExecuteConsoleCommand(m_input->GetValue().ToAscii());
+    if(result == false)
+    {
+        ConsolePrint("Invalid command\n");
+    }
+
     m_input->SetValue(wxT(""));
     event.Skip(true);
 }

--- a/wxApplication/ConsoleWindow.h
+++ b/wxApplication/ConsoleWindow.h
@@ -1,0 +1,66 @@
+/*
+Copyright (C) 2011 by Andrew Gray
+arkhaix@emunisce.com
+
+This file is part of Emunisce.
+
+Emunisce is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+The full license is available at http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+
+Emunisce is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Emunisce.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef CONSOLEWINDOW_H
+#define CONSOLEWINDOW_H
+
+#include "wx/wx.h"
+#include "wx/textctrl.h"
+
+#include <string>
+
+
+namespace Emunisce
+{
+
+class Application;
+
+class ConsoleWindow
+{
+public:
+	ConsoleWindow(Application* application, wxFrame* mainFrame);
+	virtual ~ConsoleWindow();
+
+    void GiveFocus();
+
+	// events
+	void OnKeyDown(wxKeyEvent& event);
+	void OnKeyUp(wxKeyEvent& event);
+    void OnText(wxCommandEvent& event);
+    void OnTextEnter(wxCommandEvent& event);
+    void OnSetFocus(wxFocusEvent& event);
+
+    void OnFrameClosed(wxCloseEvent& event);
+
+private:
+
+    void Initialize(Application* application, wxFrame* mainFrame);
+
+    Application* m_application;
+    wxFrame* m_mainFrame;
+
+    wxFrame* m_frame;
+    wxTextCtrl*	m_output;
+    wxTextCtrl*	m_input;
+};
+
+}   //namespace Emunisce
+
+#endif // CONSOLEWINDOW_H
+

--- a/wxApplication/ConsoleWindow.h
+++ b/wxApplication/ConsoleWindow.h
@@ -38,6 +38,9 @@ public:
 	virtual ~ConsoleWindow();
 
     void GiveFocus();
+    void Close();
+
+    void ConsolePrint(const char* text);
 
 	// events
 	void OnKeyDown(wxKeyEvent& event);

--- a/wxApplication/WindowMain.cpp
+++ b/wxApplication/WindowMain.cpp
@@ -57,7 +57,15 @@ END_EVENT_TABLE()
 void WindowMain::OnKeyDown(wxKeyEvent& event)
 {
     if(m_application != nullptr)
-        m_application->KeyDown(event.GetKeyCode());
+    {
+        if(event.GetKeyCode() == (int)'`')
+        {
+            m_application->ShowConsoleWindow();
+        }
+
+        else
+            m_application->KeyDown(event.GetKeyCode());
+    }
 }
 
 void WindowMain::OnKeyUp(wxKeyEvent& event)

--- a/wxApplication/WindowMain.cpp
+++ b/wxApplication/WindowMain.cpp
@@ -59,10 +59,7 @@ void WindowMain::OnKeyDown(wxKeyEvent& event)
     if(m_application != nullptr)
     {
         if(event.GetKeyCode() == (int)'`')
-        {
             m_application->ShowConsoleWindow();
-        }
-
         else
             m_application->KeyDown(event.GetKeyCode());
     }


### PR DESCRIPTION
The console is implemented as a new wxFrame with two wxTextCtrl elements.
This still needs a few more features before I'll be happy with it, but this is a good foundation.

Future todos:
- Window resizing (text controls don't expand yet)
- Command aliases ('ss' = 'savestate')
- Autocompletion (prefix tree, tab interception)
- Debugging commands (instruction stepping, breakpoints, memory viewing)
- Audio commands (needs interface changes)
- Recording/Playback commands (movies and macros)