### PR TITLE
Updated wxWidgets to 3.0 and set up automatic scaling of the console window text controls

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,7 @@ cc_library(
 
 new_local_repository(
     name = "wx",
-    path = "/usr/include/wx-2.8",
+    path = "/usr/include/wx-3.0",
 
     build_file_content = """
 cc_library(
@@ -32,7 +32,7 @@ cc_library(
 
 new_local_repository(
     name = "wx_gtk",
-    path = "/usr/lib/x86_64-linux-gnu/wx/include/gtk2-unicode-release-2.8",
+    path = "/usr/lib/x86_64-linux-gnu/wx/include/gtk2-unicode-3.0",
 
     build_file_content = """
 cc_library(
@@ -56,17 +56,15 @@ cc_library(
     name = "wx_gtk_libs",
     visibility = ["//visibility:public"],
     srcs = [
-        "libwx_gtk2u_gl-2.8.so",
-        "libwx_gtk2u_richtext-2.8.so",
-        "libwx_gtk2u_aui-2.8.so",
-        "libwx_gtk2u_xrc-2.8.so",
-        "libwx_gtk2u_qa-2.8.so",
-        "libwx_gtk2u_html-2.8.so",
-        "libwx_gtk2u_adv-2.8.so",
-        "libwx_gtk2u_core-2.8.so",
-        "libwx_baseu_xml-2.8.so",
-        "libwx_baseu_net-2.8.so",
-        "libwx_baseu-2.8.so",
+        "libwx_gtk2u_gl-3.0.so",
+        "libwx_gtk2u_xrc-3.0.so",
+        "libwx_gtk2u_qa-3.0.so",
+        "libwx_gtk2u_html-3.0.so",
+        "libwx_gtk2u_adv-3.0.so",
+        "libwx_gtk2u_core-3.0.so",
+        "libwx_baseu_xml-3.0.so",
+        "libwx_baseu_net-3.0.so",
+        "libwx_baseu-3.0.so",
     ],
 )
     """

--- a/wxApplication/Application.h
+++ b/wxApplication/Application.h
@@ -20,7 +20,6 @@ along with Emunisce.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef APPLICATION_H
 #define APPLICATION_H
 
-#define __GXX_ABI_VERSION 1002
 #include "wx/wx.h"
 
 #include "BaseApplication/BaseApplication.h"

--- a/wxApplication/ConsoleWindow.h
+++ b/wxApplication/ConsoleWindow.h
@@ -61,6 +61,9 @@ private:
     wxFrame* m_frame;
     wxTextCtrl*	m_output;
     wxTextCtrl*	m_input;
+
+    wxBoxSizer* m_inputSizer;
+    wxBoxSizer* m_frameSizer;
 };
 
 }   //namespace Emunisce


### PR DESCRIPTION
No major code changes required for the 3.0 update.
The console window can now also be cleanly re-initialized if closed and reopened by the user.