### PR TITLE
The win32 console now defers to BaseApplication's command handler

### DIFF
--- a/BaseApplication/BaseApplication/BaseApplication.cpp
+++ b/BaseApplication/BaseApplication/BaseApplication.cpp
@@ -520,7 +520,7 @@ bool BaseApplication::ExecuteConsoleCommand(const char* command)
             if(splitCommand.size() >= 2)
                 params = strstr(command, splitCommand[1].c_str());
 
-            ((*this).*m_consoleCommands[i].func)(commandName, params);
+            ((*this).*m_consoleCommands[i].func)(params);
 
             return true;
         }
@@ -532,7 +532,7 @@ bool BaseApplication::ExecuteConsoleCommand(const char* command)
 
 // Built-in console commands
 
-void BaseApplication::CommandHelp(const char* /*command*/, const char* /*params*/)
+void BaseApplication::CommandHelp(const char* /*params*/)
 {
     char buffer[1024];
 
@@ -545,13 +545,13 @@ void BaseApplication::CommandHelp(const char* /*command*/, const char* /*params*
     ConsolePrint("\n");
 }
 
-void BaseApplication::CommandQuit(const char* /*command*/, const char* /*params*/)
+void BaseApplication::CommandQuit(const char* /*params*/)
 {
     ConsolePrint("Shutting down...\n");
     RequestShutdown();
 }
 
-void BaseApplication::CommandLoad(const char* /*command*/, const char* /*params*/)
+void BaseApplication::CommandLoad(const char* /*params*/)
 {
     char* fileSelected = nullptr;
 
@@ -573,18 +573,18 @@ void BaseApplication::CommandLoad(const char* /*command*/, const char* /*params*
     }
 }
 
-void BaseApplication::CommandPause(const char* /*command*/, const char* /*params*/)
+void BaseApplication::CommandPause(const char* /*params*/)
 {
     Pause();    
     ConsolePrint("Emulation paused\n");
 }
-void BaseApplication::CommandRun(const char* /*command*/, const char* /*params*/)
+void BaseApplication::CommandRun(const char* /*params*/)
 {
    Run(); 
    ConsolePrint("Emulation resumed\n");
 }
 
-void BaseApplication::CommandSaveState(const char* /*command*/, const char* params)
+void BaseApplication::CommandSaveState(const char* params)
 {
     const char* stateName = "default";
     if(params != nullptr && strlen(params) == 0)
@@ -595,7 +595,7 @@ void BaseApplication::CommandSaveState(const char* /*command*/, const char* para
     ConsolePrint("Saved state "); ConsolePrint(stateName); ConsolePrint("\n");
 }
 
-void BaseApplication::CommandLoadState(const char* /*command*/, const char* params)
+void BaseApplication::CommandLoadState(const char* params)
 {
     const char* stateName = "default";
     if(params != nullptr && strlen(params) == 0)
@@ -606,7 +606,7 @@ void BaseApplication::CommandLoadState(const char* /*command*/, const char* para
     ConsolePrint("Loaded state "); ConsolePrint(stateName); ConsolePrint("\n");
 }
 
-void BaseApplication::CommandSpeed(const char* /*command*/, const char* params)
+void BaseApplication::CommandSpeed(const char* params)
 {
     double speed = 1.0;
 
@@ -620,12 +620,12 @@ void BaseApplication::CommandSpeed(const char* /*command*/, const char* params)
     ConsolePrint(buffer);
 }
 
-void BaseApplication::CommandMute(const char* /*command*/, const char* /*params*/)
+void BaseApplication::CommandMute(const char* /*params*/)
 {
     ConsolePrint("Unsupported\n");
 }
 
-void BaseApplication::CommandDisplayFilter(const char* /*command*/, const char* params)
+void BaseApplication::CommandDisplayFilter(const char* params)
 {
 	if(params == nullptr || strlen(params) == 0)
 		params = "none";
@@ -659,21 +659,21 @@ void BaseApplication::CommandDisplayFilter(const char* /*command*/, const char* 
     ConsolePrint("Set display filter to "); ConsolePrint(filterNames[filter]); ConsolePrint("\n");
 }
 
-void BaseApplication::CommandVsync(const char* /*command*/, const char* params)
+void BaseApplication::CommandVsync(const char* params)
 {
 	if(params == nullptr || strlen(params) == 0 || _stricmp(params, "0") == 0 || _stricmp(params, "off") == 0)
     {
 		SetVsync(false);
-        ConsolePrint("Disabled vsync\n");
+        ConsolePrint("Vsync disabled\n");
     }
     else
     {
         SetVsync(true);
-        ConsolePrint("Enabled vsync\n");
+        ConsolePrint("Vsync enabled\n");
     }
 }
 
-void BaseApplication::CommandBackground(const char* /*command*/, const char* params)
+void BaseApplication::CommandBackground(const char* params)
 {
 	if(params == nullptr || strlen(params) == 0 || _stricmp(params, "0") == 0 || _stricmp(params, "off") == 0)
     {

--- a/BaseApplication/BaseApplication/BaseApplication.h
+++ b/BaseApplication/BaseApplication/BaseApplication.h
@@ -135,6 +135,17 @@ public:
 	void LoadRomData(const char* name, unsigned char* buffer, unsigned int bytes) override;
 
 
+    // Console command framework
+
+    typedef void (BaseApplication::*ConsoleCommandHandler)(const char* params);
+    virtual void AddConsoleCommand(const char* command, ConsoleCommandHandler func, const char* helpText);
+    
+    virtual unsigned int NumConsoleCommands();
+    virtual const char* GetConsoleCommand(unsigned int index);
+
+    virtual bool ExecuteConsoleCommand(const char* command); ///< Returns true if the command was successfully executed. False otherwise.
+
+
 protected:
 
 	virtual Archive* OpenRomData(const char* name, bool saving) = 0;
@@ -150,31 +161,21 @@ protected:
 	virtual void CloseMacro(Archive* archive) = 0;
 
 
-    // Console command framework
-
-    typedef void (BaseApplication::*ConsoleCommandHandler)(const char* command, const char* params);
-    virtual void AddConsoleCommand(const char* command, ConsoleCommandHandler func, const char* helpText);
-    
-    virtual unsigned int NumConsoleCommands();
-    virtual const char* GetConsoleCommand(unsigned int index);
-
-    virtual bool ExecuteConsoleCommand(const char* command); ///< Returns true if the command was successfully executed. False otherwise.
-
 
     // Built-in console commands
 
-    virtual void CommandHelp(const char* command, const char* params);
-    virtual void CommandQuit(const char* command, const char* params);
-    virtual void CommandLoad(const char* command, const char* params);
-    virtual void CommandPause(const char* command, const char* params);
-    virtual void CommandRun(const char* command, const char* params);
-    virtual void CommandSaveState(const char* command, const char* params);
-    virtual void CommandLoadState(const char* command, const char* params);
-    virtual void CommandSpeed(const char* command, const char* params);
-    virtual void CommandMute(const char* command, const char* params);
-    virtual void CommandDisplayFilter(const char* command, const char* params);
-    virtual void CommandVsync(const char* command, const char* params);
-    virtual void CommandBackground(const char* command, const char* params);
+    virtual void CommandHelp(const char* params);
+    virtual void CommandQuit(const char* params);
+    virtual void CommandLoad(const char* params);
+    virtual void CommandPause(const char* params);
+    virtual void CommandRun(const char* params);
+    virtual void CommandSaveState(const char* params);
+    virtual void CommandLoadState(const char* params);
+    virtual void CommandSpeed(const char* params);
+    virtual void CommandMute(const char* params);
+    virtual void CommandDisplayFilter(const char* params);
+    virtual void CommandVsync(const char* params);
+    virtual void CommandBackground(const char* params);
 
 
 	bool m_shutdownRequested;

--- a/WindowsApplication/Emunisce/ConsoleDebugger.cpp
+++ b/WindowsApplication/Emunisce/ConsoleDebugger.cpp
@@ -105,6 +105,11 @@ void ConsoleDebugger::Run()
 	}
 }
 
+void ConsoleDebugger::Print(const char* text)
+{
+	printf("%s", text);
+}
+
 
 void ConsoleDebugger::Help()
 {
@@ -164,6 +169,10 @@ void ConsoleDebugger::FetchCommand()
 	string line = "";
 	printf("\n> ");
 	getline(cin, line);
+
+	bool baseResult = m_phoenix->ExecuteConsoleCommand(line.c_str());
+	if (baseResult == true)
+		return;
 
 	vector<string> args = SplitCommand(line);
 	if(args.empty())

--- a/WindowsApplication/Emunisce/ConsoleDebugger.h
+++ b/WindowsApplication/Emunisce/ConsoleDebugger.h
@@ -51,6 +51,8 @@ public:
 
 	void Run();
 
+	void Print(const char* text);
+
 private:
 
 	void Help();

--- a/WindowsApplication/Emunisce/Emunisce.cpp
+++ b/WindowsApplication/Emunisce/Emunisce.cpp
@@ -238,8 +238,9 @@ bool EmunisceApplication::SelectFile(char** result, const char* fileMask)
 	return false;
 }
 
-void EmunisceApplication::ConsolePrint(const char* /*text*/)
+void EmunisceApplication::ConsolePrint(const char* text)
 {
+	m_debugger->Print(text);
 }
 
 unsigned int EmunisceApplication::GetRomDataSize(const char* title)


### PR DESCRIPTION
If BaseApplication fails to execute the command, then the win32 handler will take over and use the old code path.
I also removed the unused 'command' parameter from the Command* functions.  Nothing currently needs it and I don't foresee that changing.

refs #30