### PR TITLE
Implemented command resolution from prefixes as an alternative/precur…

### DIFF
--- a/BaseApplication/BaseApplication/BaseApplication.h
+++ b/BaseApplication/BaseApplication/BaseApplication.h
@@ -40,6 +40,8 @@ class InputRecording;
 class InputManager;
 class MachineRunner;
 
+class CommandTrie;
+
 
 class BaseApplication : public IUserInterface, public IMachineToApplication
 {
@@ -205,6 +207,7 @@ protected:
     static const unsigned int MaxConsoleCommands = 1024;
     ConsoleCommandInfo m_consoleCommands[MaxConsoleCommands];
     unsigned int m_numConsoleCommands;
+	CommandTrie* m_commandTrie;
 };
 
 }	//namespace Emunisce

--- a/BaseApplication/BaseApplication/BaseApplication.vcxproj
+++ b/BaseApplication/BaseApplication/BaseApplication.vcxproj
@@ -582,6 +582,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="BaseApplication.h" />
+    <ClInclude Include="CommandTrie.h" />
     <ClInclude Include="Gui.h" />
     <ClInclude Include="InputManager.h" />
     <ClInclude Include="InputRecording.h" />
@@ -593,6 +594,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="BaseApplication.cpp" />
+    <ClCompile Include="CommandTrie.cpp" />
     <ClCompile Include="Gui.cpp" />
     <ClCompile Include="InputManager.cpp" />
     <ClCompile Include="InputRecording.cpp" />

--- a/BaseApplication/BaseApplication/BaseApplication.vcxproj.filters
+++ b/BaseApplication/BaseApplication/BaseApplication.vcxproj.filters
@@ -50,6 +50,9 @@
     <ClInclude Include="InputManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="CommandTrie.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="BaseApplication.cpp">
@@ -74,6 +77,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="InputManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CommandTrie.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/BaseApplication/BaseApplication/CommandTrie.cpp
+++ b/BaseApplication/BaseApplication/CommandTrie.cpp
@@ -5,6 +5,8 @@ using namespace Emunisce;
 #include <vector>
 using namespace std;
 
+#include <cstring> // strlen
+
 namespace Emunisce
 {
 

--- a/BaseApplication/BaseApplication/CommandTrie.cpp
+++ b/BaseApplication/BaseApplication/CommandTrie.cpp
@@ -1,0 +1,134 @@
+#include "CommandTrie.h"
+using namespace Emunisce;
+
+#include <string>
+#include <vector>
+using namespace std;
+
+namespace Emunisce
+{
+
+class CommandTrie_Private
+{
+public:
+
+	CommandTrie_Private()
+	{
+	}
+
+	CommandTrie* owner;
+
+	CommandTrie* parent;
+
+	string value;
+	CommandTrie* children[26]; //a-z
+
+	vector<CommandTrie*> leaves;
+};
+
+} // namespace Emunisce
+
+CommandTrie::CommandTrie(CommandTrie* parent)
+{
+	m_private = new CommandTrie_Private();
+	m_private->owner = this;
+	m_private->parent = parent;
+
+	m_private->value.clear();
+
+	for (auto& child : m_private->children)
+	{
+		child = nullptr;
+	}
+}
+
+CommandTrie::~CommandTrie()
+{
+	for (auto& child : m_private->children)
+	{
+		if (child != nullptr) {
+			delete child;
+		}
+	}
+
+	delete m_private;
+}
+
+
+void CommandTrie::Add(const char* command, unsigned int position)
+{
+	if (command == nullptr || strlen(command) == 0)
+		return;
+
+	//Leaf
+	if (position >= strlen(command) && m_private->parent != nullptr)
+	{
+		m_private->value = command;
+		RegisterLeaf(this);
+	}
+
+	//Not leaf
+	else
+	{
+		// Must be a-z
+		if (command[position] < 'a' || command[position] > 'z')
+			return;
+
+		unsigned int index = (unsigned int)(command[position] - 'a');
+		if (m_private->children[index] == nullptr)
+			m_private->children[index] = new CommandTrie(this);
+
+		m_private->children[index]->Add(command, position + 1);
+	}
+}
+
+const char* CommandTrie::GetValue()
+{
+	return m_private->value.c_str();
+}
+
+bool CommandTrie::IsLeaf()
+{
+	return !m_private->value.empty();
+}
+
+
+unsigned int CommandTrie::NumLeaves()
+{
+	return (unsigned int)m_private->leaves.size();
+}
+
+CommandTrie* CommandTrie::GetLeaf(unsigned int index)
+{
+	if (index >= m_private->leaves.size())
+		return nullptr;
+
+	return m_private->leaves[index];
+}
+
+CommandTrie* CommandTrie::GetNode(const char* prefix, unsigned int position)
+{
+	if (prefix == nullptr)
+		return nullptr;
+
+	if (position >= strlen(prefix) && m_private->parent != nullptr)
+		return this;
+
+	unsigned int index = (unsigned int)(prefix[position] - 'a');
+	if (m_private->children[index] == nullptr)
+		return nullptr;
+
+	return m_private->children[index]->GetNode(prefix, position + 1);
+}
+
+void CommandTrie::RegisterLeaf(CommandTrie* leaf)
+{
+	if (leaf == nullptr)
+		return;
+
+	m_private->leaves.push_back(leaf);
+	if (m_private->parent != nullptr)
+	{
+		m_private->parent->RegisterLeaf(leaf);
+	}
+}

--- a/BaseApplication/BaseApplication/CommandTrie.h
+++ b/BaseApplication/BaseApplication/CommandTrie.h
@@ -1,0 +1,33 @@
+#ifndef COMMANDTRIE_H
+#define COMMANDTRIE_H
+
+namespace Emunisce
+{
+
+class CommandTrie
+{
+public:
+
+	CommandTrie(CommandTrie* parent = nullptr);
+	~CommandTrie();
+
+	void Add(const char* command, unsigned int position = 0);
+	const char* GetValue();
+
+	bool IsLeaf();
+
+	unsigned int NumLeaves();
+	CommandTrie* GetLeaf(unsigned int index);
+
+	CommandTrie* GetNode(const char* prefix, unsigned int position = 0);
+
+private:
+
+	void RegisterLeaf(CommandTrie* leaf);
+
+	class CommandTrie_Private* m_private;
+};
+
+}
+
+#endif

--- a/WindowsApplication/Emunisce/ConsoleDebugger.cpp
+++ b/WindowsApplication/Emunisce/ConsoleDebugger.cpp
@@ -170,9 +170,16 @@ void ConsoleDebugger::FetchCommand()
 	printf("\n> ");
 	getline(cin, line);
 
-	bool baseResult = m_phoenix->ExecuteConsoleCommand(line.c_str());
-	if (baseResult == true)
-		return;
+	if (m_phoenix->ExecuteConsoleCommand(line.c_str()) == false)
+		printf("Unrecognized command.  Use 'help' for a list of valid commands.\n");
+
+	// The remaining code is here only for reference while it gets migrated to BaseApplication
+
+#if true
+
+	return;
+
+#else
 
 	vector<string> args = SplitCommand(line);
 	if(args.empty())
@@ -317,6 +324,7 @@ void ConsoleDebugger::FetchCommand()
 	{
 		printf("Unrecognized command.  Use 'help' for a list of valid commands.\n");
 	}
+#endif
 }
 
 vector<string> ConsoleDebugger::SplitCommand(string command)


### PR DESCRIPTION
…sor to auto-completion

- Added a prefix tree implementation (CommandTrie) that is used by BaseApplication to store prefixes for registered commands.
- BaseApplication::ExecuteCommand now looks up the possible prefixes and executes it if the prefix matches one (and only one) possible command.

I still hope to add tab-to-autocomplete later.

refs #15