### PR TITLE
Implemented tab-to-autocomplete in the win32 console

### DIFF
--- a/BaseApplication/BaseApplication/BaseApplication.cpp
+++ b/BaseApplication/BaseApplication/BaseApplication.cpp
@@ -561,6 +561,33 @@ bool BaseApplication::ExecuteConsoleCommand(const char* command)
     return false;
 }
 
+unsigned int BaseApplication::NumPossibleCommands(const char* prefix)
+{
+	CommandTrie* node = m_commandTrie->GetNode(prefix);
+
+	if (node == nullptr)
+		return 0;
+
+	return node->NumLeaves();
+}
+
+const char* BaseApplication::GetPossibleCommand(const char* prefix, unsigned int index)
+{
+	CommandTrie* node = m_commandTrie->GetNode(prefix);
+
+	if (node == nullptr)
+		return 0;
+
+	if (index >= node->NumLeaves())
+		return nullptr;
+
+	CommandTrie* leaf = node->GetLeaf(index);
+	if (leaf == nullptr)
+		return nullptr;
+
+	return leaf->GetValue();
+}
+
 
 // Built-in console commands
 

--- a/BaseApplication/BaseApplication/BaseApplication.h
+++ b/BaseApplication/BaseApplication/BaseApplication.h
@@ -147,6 +147,9 @@ public:
 
     virtual bool ExecuteConsoleCommand(const char* command); ///< Returns true if the command was successfully executed. False otherwise.
 
+	virtual unsigned int NumPossibleCommands(const char* prefix);
+	virtual const char* GetPossibleCommand(const char* prefix, unsigned int index);
+
 
 protected:
 

--- a/BaseApplication/BaseApplication/CommandTrie.cpp
+++ b/BaseApplication/BaseApplication/CommandTrie.cpp
@@ -110,8 +110,8 @@ CommandTrie* CommandTrie::GetLeaf(unsigned int index)
 
 CommandTrie* CommandTrie::GetNode(const char* prefix, unsigned int position)
 {
-	if (prefix == nullptr)
-		return nullptr;
+	if (prefix == nullptr || strlen(prefix) == 0)
+		return this;
 
 	if (position >= strlen(prefix) && m_private->parent != nullptr)
 		return this;

--- a/WindowsApplication/Emunisce/ConsoleDebugger.h
+++ b/WindowsApplication/Emunisce/ConsoleDebugger.h
@@ -61,6 +61,7 @@ private:
 
 	void UpdateDisplay();
 	void FetchCommand();
+	string FetchLine();
 
 	vector<string> SplitCommand(string command);
 


### PR DESCRIPTION
Tab will cycle through the available auto-complete options matching the prefix the user has typed.
Pressing tab first (without any prefix) will begin cycling through all available commands.
Pressing tab on a prefix with no matching commands will do nothing.

refs #15